### PR TITLE
Simplify query logic for AllRegions.get()

### DIFF
--- a/pysquirrel/__init__.py
+++ b/pysquirrel/__init__.py
@@ -1,6 +1,6 @@
 """pysquirrel"""
 
-from . import core
+from .core import AllRegions
 
 # create database
-nuts = core.AllRegions()
+nuts = AllRegions()

--- a/pysquirrel/core.py
+++ b/pysquirrel/core.py
@@ -109,7 +109,6 @@ class AllRegions:
 
     def __init__(self) -> None:
         self._load()
-        self._set_index()
 
     def _load(self) -> None:
         """
@@ -148,20 +147,11 @@ class AllRegions:
         :param param: field to be searched
         :param value: value(s) to be searched in the field
         """
-        results = set(
-            flatten(
-                [
-                    self.search_index[param][key]
-                    for key in self.search_index[param]
-                    if key == value
-                ]
-            )
-        )
-
+        results = set(flatten([i for i in self.data if getattr(i, param) == value]))
         return results
 
     def get(
-        self, *, country_code: str | list[str] = None, level: int | list[int]
+        self, *, country_code: str | list[str] = None, level: int | list[int] = None
     ) -> list[NUTSRegion | SRRegion, None]:
         """
         Searches NUTS 2024 classification database by country code(s) and/or
@@ -177,5 +167,8 @@ class AllRegions:
         for param, values in {"country_code": country_code, "level": level}.items():
             if isinstance(values, (int, str)):
                 values = [values]
-            results.append(set.union(*[self._search(param, value) for value in values]))
+            if values:
+                results.append(
+                    set.union(*[self._search(param, value) for value in values])
+                )
         return list(set.intersection(*results))

--- a/pysquirrel/core.py
+++ b/pysquirrel/core.py
@@ -172,16 +172,10 @@ class AllRegions:
         :param level: NUTS level(s) to search
         """
         results = []
-        if country_code or level:
-            for param, values in {"country_code": country_code, "level": level}.items():
-                if isinstance(values, (int, str)):
-                    result = self._search(param, values)
-                    results.append(result)
-                elif isinstance(values, list):
-                    result = []
-                    for value in values:
-                        result.append(self._search(param, value))
-                    results.append(set.union(*result))
-            return list(set.intersection(*results))
-        else:
+        if not (country_code or level):
             raise ValueError("no keyword argument(s) passed.")
+        for param, values in {"country_code": country_code, "level": level}.items():
+            if isinstance(values, (int, str)):
+                values = [values]
+            results.append(set.union(*[self._search(param, value) for value in values]))
+        return list(set.intersection(*results))

--- a/pysquirrel/core.py
+++ b/pysquirrel/core.py
@@ -147,8 +147,7 @@ class AllRegions:
         :param param: field to be searched
         :param value: value(s) to be searched in the field
         """
-        results = set(flatten([i for i in self.data if getattr(i, param) == value]))
-        return results
+        return set(i for i in self.data if getattr(i, param) == value)
 
     def get(
         self, *, country_code: str | list[str] = None, level: int | list[int] = None
@@ -169,6 +168,6 @@ class AllRegions:
                 values = [values]
             if values:
                 results.append(
-                    set.union(*[self._search(param, value) for value in values])
+                    set.union(*(self._search(param, value) for value in values))
                 )
         return list(set.intersection(*results))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,61 @@
+import pytest
+
+from pysquirrel.core import Level, NUTSRegion, AllRegions
+from pydantic import ValidationError
+
+SAMPLE_DATA = [
+    NUTSRegion(country_code="AT", code="AT1", label="Ostösterreich", level=1),
+    NUTSRegion(country_code="AT", code="AT12", label="Niederösterreich", level=2),
+    NUTSRegion(country_code="AT", code="AT127", label="Wiener Umland/Südteil", level=3),
+    NUTSRegion(country_code="PT", code="PT1", label="Continente", level=1),
+    NUTSRegion(country_code="PT", code="PT1C", label="Alentejo", level=2),
+    NUTSRegion(country_code="PT", code="PT1C1", label="Alentejo Litoral", level=3),
+]
+
+
+class TestRegionClass:
+    def test_region_creation(self):
+        region = SAMPLE_DATA[2]
+        assert region.country_code == "AT"
+        assert region.code == "AT127"
+        assert region.label == "Wiener Umland/Südteil"
+        assert region.level == Level.LEVEL_3
+
+    def test_invalid_country_code(self):
+        with pytest.raises(ValidationError):
+            NUTSRegion(
+                country_code="at", code="AT127", label="Wiener Umland/Südteil", level=3
+            )
+
+    def test_invalid_region_code(self):
+        with pytest.raises(ValidationError):
+            NUTSRegion(
+                country_code="AT", code="A127", label="Wiener Umland/Südteil", level=3
+            )
+
+
+def mock_load(self):
+    """Mocked _load method that loads a sample dataset."""
+    self.data = SAMPLE_DATA
+
+
+def test_all_regions(monkeypatch):
+    # Create an instance of AllRegions
+    all_regions = AllRegions()
+
+    # Replace the _load method with the mock method
+    monkeypatch.setattr(AllRegions, "_load", mock_load)
+
+    # Call _load to apply the mock
+    all_regions._load()
+
+    # Check if the data is loaded correctly
+    assert len(all_regions.data) == 6
+
+    # Check if returned data sets are equivalent (get() processing might change order of results)
+    assert set(all_regions.get(country_code="AT")) == set(SAMPLE_DATA[:3])
+    assert set(all_regions.get(country_code="PT")) == set(SAMPLE_DATA[3:])
+    assert set(all_regions.get(level=2)) == set([SAMPLE_DATA[1], SAMPLE_DATA[4]])
+    assert set(all_regions.get(country_code="AT", level=1)) == set([SAMPLE_DATA[0]])
+    assert set(all_regions.get(country_code="PT", level=3)) == set([SAMPLE_DATA[-1]])
+    assert set(all_regions.get(country_code=["AT", "PT"])) == set(SAMPLE_DATA)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,7 @@ import pytest
 from pysquirrel.core import Level, NUTSRegion, AllRegions
 from pydantic import ValidationError
 
-SAMPLE_DATA = [
+MOCK_DATA = [
     NUTSRegion(country_code="AT", code="AT1", label="Ostösterreich", level=1),
     NUTSRegion(country_code="AT", code="AT12", label="Niederösterreich", level=2),
     NUTSRegion(country_code="AT", code="AT127", label="Wiener Umland/Südteil", level=3),
@@ -13,35 +13,50 @@ SAMPLE_DATA = [
 ]
 
 
-class TestRegionClass:
-    def test_region_creation(self):
-        region = SAMPLE_DATA[2]
-        assert region.country_code == "AT"
-        assert region.code == "AT127"
-        assert region.label == "Wiener Umland/Südteil"
-        assert region.level == Level.LEVEL_3
+def test_region_creation():
+    region = MOCK_DATA[2]
+    assert region.country_code == "AT"
+    assert region.code == "AT127"
+    assert region.label == "Wiener Umland/Südteil"
+    assert region.level == Level.LEVEL_3
 
-    def test_invalid_country_code(self):
-        with pytest.raises(ValidationError):
-            NUTSRegion(
-                country_code="at", code="AT127", label="Wiener Umland/Südteil", level=3
-            )
 
-    def test_invalid_region_code(self):
-        with pytest.raises(ValidationError):
-            NUTSRegion(
-                country_code="AT", code="A127", label="Wiener Umland/Südteil", level=3
-            )
+def test_invalid_country_code():
+    with pytest.raises(ValidationError):
+        NUTSRegion(
+            country_code="at", code="AT127", label="Wiener Umland/Südteil", level=3
+        )
+
+
+def test_invalid_region_code():
+    with pytest.raises(ValidationError):
+        NUTSRegion(
+            country_code="AT", code="A127", label="Wiener Umland/Südteil", level=3
+        )
 
 
 def mock_load(self):
     """Mocked _load method that loads a sample dataset."""
-    self.data = SAMPLE_DATA
+    self.data = MOCK_DATA
 
 
 def test_all_regions(monkeypatch):
     # Create an instance of AllRegions
     all_regions = AllRegions()
+
+    # Test full data import
+    assert len(all_regions.get(level=1)) == 160
+    assert len(all_regions.get(level=2)) == 361
+    assert len(all_regions.get(level=3)) == 1521
+
+    # Test data fields
+    lux = [
+        nuts
+        for nuts in all_regions.get(country_code="LU", level=1)
+        if "Z" not in nuts.code  # exclude Extra-Regio NUTS 1
+    ]
+    assert len(lux) == 1
+    assert lux[0].label == "Luxembourg" and lux[0].code == "LU0"
 
     # Replace the _load method with the mock method
     monkeypatch.setattr(AllRegions, "_load", mock_load)
@@ -52,10 +67,10 @@ def test_all_regions(monkeypatch):
     # Check if the data is loaded correctly
     assert len(all_regions.data) == 6
 
-    # Check if returned data sets are equivalent (get() processing might change order of results)
-    assert set(all_regions.get(country_code="AT")) == set(SAMPLE_DATA[:3])
-    assert set(all_regions.get(country_code="PT")) == set(SAMPLE_DATA[3:])
-    assert set(all_regions.get(level=2)) == set([SAMPLE_DATA[1], SAMPLE_DATA[4]])
-    assert set(all_regions.get(country_code="AT", level=1)) == set([SAMPLE_DATA[0]])
-    assert set(all_regions.get(country_code="PT", level=3)) == set([SAMPLE_DATA[-1]])
-    assert set(all_regions.get(country_code=["AT", "PT"])) == set(SAMPLE_DATA)
+    # Test query logic with mock data
+    assert set(all_regions.get(country_code="AT")) == set(MOCK_DATA[:3])
+    assert set(all_regions.get(country_code="PT")) == set(MOCK_DATA[3:])
+    assert set(all_regions.get(level=2)) == set([MOCK_DATA[1], MOCK_DATA[4]])
+    assert set(all_regions.get(country_code="AT", level=1)) == set([MOCK_DATA[0]])
+    assert set(all_regions.get(country_code="PT", level=3)) == set([MOCK_DATA[-1]])
+    assert set(all_regions.get(country_code=["AT", "PT"])) == set(MOCK_DATA)


### PR DESCRIPTION
Closes #12, resolves #19. Simplifies and changes logic to AND _inter_ field and OR _intra_ field, for country codes and NUTS levels, e.g.: `pysquirrel.nuts.get(country_code=["BE", "AT"], level=[2,3])` returns all NUTS2 and NUTS3 regions for Belgium and Austria. Search index is removed.