### PR TITLE
Add option to include/exclude Extra-Regio NUTS regions and update tests

### DIFF
--- a/pysquirrel/core.py
+++ b/pysquirrel/core.py
@@ -1,3 +1,5 @@
+"""Core data models and region database for pysquirrel."""
+
 from dataclasses import fields
 from enum import IntEnum
 from pathlib import Path
@@ -112,6 +114,10 @@ class Region:
     def parent_code(self) -> str | None:
         return self.code[:-1] if self.level > 1 else None
 
+    @property
+    def is_extra_regio(self) -> bool:
+        return all(c == "Z" for c in self.code[len(self.country_code) :])
+
     @field_validator("country_code")
     @classmethod
     def check_country_code(cls, v: str):
@@ -156,6 +162,11 @@ class Region:
             and len(self.code) == len(self.country_code) + self.level
         ):
             return self
+        else:
+            raise ValueError(
+                f"code '{self.code}' is inconsistent with country_code "
+                f"'{self.country_code}' and level {self.level}."
+            )
 
 
 class NUTSRegion(Region):
@@ -216,6 +227,7 @@ class AllRegions:
         country_code: str | list[str] = None,
         iso3: str | list[str] = None,
         level: int | list[int] = None,
+        include_extra_regio: bool = False,
     ) -> list[NUTSRegion | SRRegion, None]:
         """
         Searches NUTS 2024 classification database by country code(s), ISO3 code, or
@@ -225,8 +237,11 @@ class AllRegions:
         :param country_code: country code(s) to search
         :param iso3: ISO3 code(s) to search
         :param level: NUTS level(s) to search
+        :param include_extra_regio: if True, include Extra-Regio NUTS regions
+            (codes where all characters after the country code are 'Z',
+            e.g. BEZ, BEZZ, BEZZZ). Defaults to False.
         """
-        results = []
+        results: list[Region] = []
         if not (country_code or level or iso3):
             raise ValueError("no keyword argument(s) passed.")
 
@@ -237,7 +252,7 @@ class AllRegions:
             iso2_codes: list[str] = []
             for v in iso3_codes:
                 if not isinstance(v, str):
-                    raise ValueError("iso3 codes must be strings")
+                    raise ValueError("ISO3 codes must be strings")
                 v_up = v.upper()
                 # Accept both 3-letter ISO3 and 2-letter ISO2 passed accidentally.
                 if len(v_up) == 3:
@@ -250,7 +265,7 @@ class AllRegions:
                 else:
                     raise ValueError(f"invalid ISO code: {v}")
 
-            # Merge converted iso2 values into country_code argument
+            # Merge converted ISO2 values into country_code argument
             if country_code:
                 # normalize existing country_code into list
                 if isinstance(country_code, (str, int)):
@@ -265,4 +280,9 @@ class AllRegions:
                 results.append(
                     set.union(*(self._search(param, value) for value in values))
                 )
-        return list(set.intersection(*results))
+        matched = (
+            {r for r in set.intersection(*results) if not r.is_extra_regio}
+            if not include_extra_regio
+            else set.intersection(*results)
+        )
+        return list(matched)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,98 +1,161 @@
+"""Tests for region models and AllRegions database."""
+
 import pytest
 
 from pysquirrel.core import Level, NUTSRegion, SRRegion, AllRegions
 from pydantic import ValidationError
 
-MOCK_DATA = [
-    NUTSRegion(country_code="AT", code="AT1", label="Ostösterreich", level=1),
-    NUTSRegion(country_code="AT", code="AT12", label="Niederösterreich", level=2),
-    NUTSRegion(country_code="AT", code="AT127", label="Wiener Umland/Südteil", level=3),
-    NUTSRegion(country_code="PT", code="PT1", label="Continente", level=1),
-    NUTSRegion(country_code="PT", code="PT1C", label="Alentejo", level=2),
-    NUTSRegion(country_code="PT", code="PT1C1", label="Alentejo Litoral", level=3),
-    SRRegion(country_code="IS", code="IS0", label="Ísland", level=1),  # SR
-]
+AT1 = NUTSRegion(country_code="AT", code="AT1", label="Ostösterreich", level=1)
+AT12 = NUTSRegion(country_code="AT", code="AT12", label="Niederösterreich", level=2)
+AT127 = NUTSRegion(
+    country_code="AT", code="AT127", label="Wiener Umland/Südteil", level=3
+)
+PT1 = NUTSRegion(country_code="PT", code="PT1", label="Continente", level=1)
+PT1C = NUTSRegion(country_code="PT", code="PT1C", label="Alentejo", level=2)
+PT1C1 = NUTSRegion(country_code="PT", code="PT1C1", label="Alentejo Litoral", level=3)
+IS0 = SRRegion(country_code="IS", code="IS0", label="Ísland", level=1)
+
+MOCK_DATA = [AT1, AT12, AT127, PT1, PT1C, PT1C1, IS0]
+
+
+@pytest.fixture
+def mock_db(monkeypatch):
+    """AllRegions instance loaded with MOCK_DATA instead of real data files."""
+
+    def _mock_load(self):
+        self.data = MOCK_DATA
+
+    monkeypatch.setattr(AllRegions, "_load", _mock_load)
+    db = AllRegions()
+    return db
 
 
 def test_region_creation():
-    region = MOCK_DATA[2]
-    assert region.country_code == "AT"
-    assert region.code == "AT127"
-    assert region.label == "Wiener Umland/Südteil"
-    assert region.level == Level.LEVEL_3
+    """Test region fields are stored and exposed correctly."""
+    assert AT127.country_code == "AT"
+    assert AT127.code == "AT127"
+    assert AT127.label == "Wiener Umland/Südteil"
+    assert AT127.level == Level.LEVEL_3
 
 
-def test_invalid_country_code():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "country_code": "at",
+            "code": "AT127",
+            "label": "Wiener Umland/Südteil",
+            "level": 3,
+        },
+        {
+            "country_code": "AT",
+            "code": "A127",
+            "label": "Wiener Umland/Südteil",
+            "level": 3,
+        },
+    ],
+)
+def test_invalid_region(kwargs):
+    """Test invalid country or region codes raise a ValidationError."""
     with pytest.raises(ValidationError):
-        NUTSRegion(
-            country_code="at", code="AT127", label="Wiener Umland/Südteil", level=3
-        )
+        NUTSRegion(**kwargs)
 
 
-def test_invalid_region_code():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # code does not start with country_code
+        {"country_code": "AT", "code": "DE1", "label": "Mismatch", "level": 1},
+        # code length inconsistent with level (level 2 needs 4 chars, got 5)
+        {"country_code": "AT", "code": "AT127", "label": "Mismatch", "level": 2},
+    ],
+)
+def test_code_consistency(kwargs):
+    """Test that mismatches between code, country_code, and level raise ValidationError."""
     with pytest.raises(ValidationError):
-        NUTSRegion(
-            country_code="AT", code="A127", label="Wiener Umland/Südteil", level=3
-        )
+        NUTSRegion(**kwargs)
 
 
-def mock_load(self):
-    """Mocked _load method that loads a sample dataset."""
-    self.data = MOCK_DATA
+def test_is_extra_regio():
+    """Test `is_extra_regio` is True for Z-suffix codes and False for normal codes."""
+    extra = NUTSRegion(
+        country_code="BE", code="BEZ", label="Extra-Regio NUTS 1", level=1
+    )
+    assert extra.is_extra_regio is True
+    assert AT1.is_extra_regio is False
 
 
-def test_all_regions(monkeypatch):
-    # Create an instance of AllRegions
-    all_regions = AllRegions()
-
-    # Test full data import
-    assert len(all_regions.get(level=1)) == 174
-    assert len(all_regions.get(level=2)) == 406
-    assert len(all_regions.get(level=3)) == 1700
-
-    # Test UK NUTS import
-    assert len(all_regions.get(country_code="UK")) == 232
-
-    # Test data fields
-    lux = [
-        nuts
-        for nuts in all_regions.get(country_code="LU", level=1)
-        if "Z" not in nuts.code  # exclude Extra-Regio NUTS 1
-    ]
-    assert len(lux) == 1
-    assert lux[0].label == "Luxembourg" and lux[0].code == "LU0"
-
-    # Replace the _load method with the mock method
-    monkeypatch.setattr(AllRegions, "_load", mock_load)
-
-    # Call _load to apply the mock
-    all_regions._load()
-
-    # Check if the data is loaded correctly
-    assert len(all_regions.data) == 7
-
-    # Test query logic with mock data
-    assert set(all_regions.get(country_code="AT")) == set(MOCK_DATA[:3])
-    assert set(all_regions.get(country_code="PT")) == set(MOCK_DATA[3:-1])
-    assert set(all_regions.get(level=2)) == set([MOCK_DATA[1], MOCK_DATA[4]])
-    assert set(all_regions.get(country_code="AT", level=1)) == set([MOCK_DATA[0]])
-    assert set(all_regions.get(country_code="PT", level=3)) == set([MOCK_DATA[-2]])
-    assert set(all_regions.get(country_code="IS")) == set([MOCK_DATA[-1]])
+@pytest.fixture(scope="module")
+def real_db():
+    return AllRegions()
 
 
-def test_iso3_lookup(monkeypatch):
-    """Test ISO3 lookup support via the `iso3` parameter."""
-    all_regions = AllRegions()
+@pytest.mark.parametrize("level,expected", [(1, 135), (2, 367), (3, 1662)])
+def test_counts_exclude_extra_regio(real_db, level, expected):
+    """Test region counts per level exclude Extra-Regio entries by default."""
+    assert len(real_db.get(level=level)) == expected
 
-    # Replace the _load method with the mock method and reload
-    monkeypatch.setattr(AllRegions, "_load", mock_load)
-    all_regions._load()
 
-    # Single ISO3 lookup
-    assert set(all_regions.get(iso3="AUT")) == set(MOCK_DATA[:3])
+@pytest.mark.parametrize("level,expected", [(1, 174), (2, 406), (3, 1700)])
+def test_counts_include_extra_regio(real_db, level, expected):
+    """Test region counts per level include Extra-Regio entries when requested."""
+    assert len(real_db.get(level=level, include_extra_regio=True)) == expected
 
-    # Multiple ISO3 lookup
-    assert set(all_regions.get(iso3=["AUT", "PRT"])) == set(MOCK_DATA[:-1])
 
-    # Accept ISO2 in the iso3 parameter as well
-    assert set(all_regions.get(iso3="PT")) == set(MOCK_DATA[3:-1])
+def test_uk_import(real_db):
+    """Test UK NUTS regions from the supplementary file are imported correctly."""
+    assert len(real_db.get(country_code="UK")) == 232
+
+
+def test_mock_data_loaded(mock_db):
+    """Test the mock fixture loads exactly the expected number of regions."""
+    assert len(mock_db.data) == len(MOCK_DATA)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"country_code": "AT"}, {AT1, AT12, AT127}),
+        ({"country_code": "PT"}, {PT1, PT1C, PT1C1}),
+        ({"country_code": "IS"}, {IS0}),
+        ({"level": 2}, {AT12, PT1C}),
+        ({"country_code": "AT", "level": 1}, {AT1}),
+        ({"country_code": "PT", "level": 3}, {PT1C1}),
+    ],
+)
+def test_query(mock_db, kwargs, expected):
+    """Test get() filters correctly by country_code and/or level."""
+    assert set(mock_db.get(**kwargs)) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"iso3": "AUT"}, {AT1, AT12, AT127}),
+        ({"iso3": ["AUT", "PRT"]}, {AT1, AT12, AT127, PT1, PT1C, PT1C1}),
+        ({"iso3": "PT"}, {PT1, PT1C, PT1C1}),  # ISO2 accepted in iso3 param
+    ],
+)
+def test_iso3_lookup(mock_db, kwargs, expected):
+    """Test get() resolves ISO3 (and ISO2 passed as iso3) to the correct regions."""
+    assert set(mock_db.get(**kwargs)) == expected
+
+
+def test_get_no_args_raises(mock_db):
+    """Test get() raises ValueError when called with no arguments."""
+    with pytest.raises(ValueError, match="no keyword argument"):
+        mock_db.get()
+
+
+@pytest.mark.parametrize(
+    "iso3, exc_match",
+    [
+        ("XYZ", "unknown ISO3 code"),
+        ("TOOLONG", "invalid ISO code"),
+        (123, "ISO3 codes must be strings"),
+    ],
+)
+def test_iso3_invalid_raises(mock_db, iso3, exc_match):
+    """Test get() raises ValueError for unrecognised or malformed iso3 values."""
+    with pytest.raises(ValueError, match=exc_match):
+        mock_db.get(iso3=iso3)


### PR DESCRIPTION
A quick PR after I went over pysquirrel with Lisah.
Added an option to include placeholder Extra-Regio NUTS regions, and updated tests for better formatting.

This departs from the previous default which included these placeholders, they are now default opt-out.